### PR TITLE
feat: liste d'attente pour la page Communauté (bouton « Me notifier »)

### DIFF
--- a/api-fastify/src/controllers/waitlist.controller.ts
+++ b/api-fastify/src/controllers/waitlist.controller.ts
@@ -1,0 +1,27 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { JoinWaitlistInput } from '../types/waitlist.types.js';
+import * as WaitlistService from '../services/waitlist.service.js';
+
+/**
+ * Contrôleur pour rejoindre la liste d'attente d'une fonctionnalité à venir
+ */
+export const joinWaitlist = async (
+  request: FastifyRequest<{ Body: JoinWaitlistInput }>,
+  reply: FastifyReply
+) => {
+  try {
+    const { alreadyRegistered } = await WaitlistService.joinWaitlist(request.body);
+
+    return reply.status(200).send({
+      message: alreadyRegistered
+        ? 'Vous êtes déjà inscrit. Nous vous préviendrons dès que ce sera prêt !'
+        : 'Merci ! Nous vous préviendrons dès que ce sera disponible.',
+      alreadyRegistered,
+    });
+  } catch (error) {
+    request.log.error(error instanceof Error ? error : new Error(String(error)));
+    return reply.status(500).send({
+      message: 'Une erreur est survenue lors de l\'inscription à la liste d\'attente',
+    });
+  }
+};

--- a/api-fastify/src/models/waitlist.model.ts
+++ b/api-fastify/src/models/waitlist.model.ts
@@ -1,0 +1,28 @@
+import mongoose, { Schema } from 'mongoose';
+import { IWaitlistEntry } from '../types/waitlist.types.js';
+
+const waitlistSchema = new Schema<IWaitlistEntry>(
+  {
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      lowercase: true,
+      match: [/^\S+@\S+\.\S+$/, 'Veuillez fournir une adresse email valide'],
+    },
+    // Origine de l'inscription (ex: la feature pour laquelle l'utilisateur s'inscrit)
+    source: {
+      type: String,
+      trim: true,
+      default: 'community',
+      maxlength: 50,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// Créer et exporter le modèle WaitlistEntry
+export const WaitlistEntry = mongoose.model<IWaitlistEntry>('WaitlistEntry', waitlistSchema);

--- a/api-fastify/src/routes/index.ts
+++ b/api-fastify/src/routes/index.ts
@@ -9,6 +9,7 @@ import { uploadRoutes } from './upload.routes.js';
 import { aiRoutes } from './ai.routes.js';
 import { healthRoutes } from './health.routes.js';
 import { notificationRoutes } from './notification.routes.js';
+import { waitlistRoutes } from './waitlist.routes.js';
 
 
 /**
@@ -48,5 +49,8 @@ export function registerRoutes(server: FastifyInstance): void {
 
   // Enregistrer les routes des notifications admin
   server.register(notificationRoutes, { prefix: `${API_PREFIX}/admin/notifications` });
+
+  // Enregistrer les routes de la liste d'attente
+  server.register(waitlistRoutes, { prefix: `${API_PREFIX}/waitlist` });
 
 }

--- a/api-fastify/src/routes/waitlist.routes.ts
+++ b/api-fastify/src/routes/waitlist.routes.ts
@@ -1,0 +1,27 @@
+import { FastifyInstance } from 'fastify';
+import * as WaitlistController from '../controllers/waitlist.controller.js';
+import { joinWaitlistSchema } from '../schemas/waitlist.schema.js';
+import { createRateLimitMiddleware } from '../middlewares/rate-limit.middleware.js';
+import { JoinWaitlistInput } from '../types/waitlist.types.js';
+
+// Limite anti-spam : 5 inscriptions par minute et par IP
+const waitlistRateLimit = createRateLimitMiddleware({
+  windowMs: 60 * 1000,
+  maxRequests: 5,
+});
+
+/**
+ * Routes pour la liste d'attente
+ * @param fastify Instance Fastify
+ */
+export async function waitlistRoutes(fastify: FastifyInstance): Promise<void> {
+  // Route publique pour rejoindre la liste d'attente
+  fastify.post<{ Body: JoinWaitlistInput }>(
+    '/',
+    {
+      schema: joinWaitlistSchema,
+      preHandler: [waitlistRateLimit],
+    },
+    WaitlistController.joinWaitlist
+  );
+}

--- a/api-fastify/src/schemas/waitlist.schema.ts
+++ b/api-fastify/src/schemas/waitlist.schema.ts
@@ -1,0 +1,25 @@
+import { FastifySchema } from 'fastify';
+
+/**
+ * Schéma de validation pour rejoindre la liste d'attente
+ */
+export const joinWaitlistSchema: FastifySchema = {
+  body: {
+    type: 'object',
+    required: ['email'],
+    additionalProperties: false,
+    properties: {
+      email: { type: 'string', format: 'email', maxLength: 254 },
+      source: { type: 'string', maxLength: 50 },
+    },
+  },
+  response: {
+    200: {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+        alreadyRegistered: { type: 'boolean' },
+      },
+    },
+  },
+};

--- a/api-fastify/src/services/waitlist.service.ts
+++ b/api-fastify/src/services/waitlist.service.ts
@@ -1,0 +1,19 @@
+import { WaitlistEntry } from '../models/waitlist.model.js';
+import { JoinWaitlistInput } from '../types/waitlist.types.js';
+
+/**
+ * Inscrit une adresse email à la liste d'attente.
+ * Opération idempotente : une email déjà inscrite ne provoque pas d'erreur.
+ */
+export const joinWaitlist = async (data: JoinWaitlistInput) => {
+  const email = data.email.trim().toLowerCase();
+  const source = data.source?.trim() || 'community';
+
+  const existing = await WaitlistEntry.findOne({ email });
+  if (existing) {
+    return { alreadyRegistered: true };
+  }
+
+  await WaitlistEntry.create({ email, source });
+  return { alreadyRegistered: false };
+};

--- a/api-fastify/src/types/waitlist.types.ts
+++ b/api-fastify/src/types/waitlist.types.ts
@@ -1,0 +1,19 @@
+import { Document } from 'mongoose';
+
+/**
+ * Interface pour une inscription à la liste d'attente
+ */
+export interface IWaitlistEntry extends Document {
+  email: string;
+  source: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Type pour rejoindre la liste d'attente
+ */
+export type JoinWaitlistInput = {
+  email: string;
+  source?: string;
+};

--- a/src/config/api.config.ts
+++ b/src/config/api.config.ts
@@ -89,6 +89,11 @@ export const API_ENDPOINTS = {
 
   // Santé de l'API
   health: `${API_BASE_URL}/health`,
+
+  // Liste d'attente (fonctionnalités à venir)
+  waitlist: {
+    join: `${API_BASE_URL}/waitlist`,
+  },
 };
 
 /**

--- a/src/pages/ComingSoon.tsx
+++ b/src/pages/ComingSoon.tsx
@@ -1,12 +1,65 @@
-import React from "react"
+import React, { useState } from "react"
 import { Link } from "react-router-dom"
 import { Container } from "../components/ui/container"
 import { Button } from "../components/ui/button"
+import { Input } from "../components/ui/input"
 import { H1 } from "../components/ui/typography"
 import AnimateOnView from "../components/AnimateOnView"
-import { ArrowLeft, Users, Clock, Bell } from "lucide-react"
+import { ArrowLeft, Users, Clock, Bell, Loader2 } from "lucide-react"
+import { API_ENDPOINTS } from "../config/api.config"
+import { toast } from "../hooks/use-toast"
+
+const EMAIL_REGEX = /^\S+@\S+\.\S+$/
 
 export default function ComingSoon() {
+  const [showForm, setShowForm] = useState(false)
+  const [email, setEmail] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const trimmed = email.trim()
+    if (!EMAIL_REGEX.test(trimmed)) {
+      toast({
+        title: "Email invalide",
+        description: "Veuillez saisir une adresse email valide.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const res = await fetch(API_ENDPOINTS.waitlist.join, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: trimmed, source: "community" }),
+      })
+
+      const data = await res.json().catch(() => ({}))
+
+      if (!res.ok) {
+        throw new Error(data?.message || "Échec de l'inscription")
+      }
+
+      toast({
+        title: "C'est noté !",
+        description: data?.message || "Nous vous préviendrons dès que ce sera disponible.",
+      })
+      setEmail("")
+      setShowForm(false)
+    } catch (err) {
+      toast({
+        title: "Oups",
+        description: err instanceof Error ? err.message : "Une erreur est survenue. Réessayez plus tard.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
     <main className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center">
       <Container className="text-center">
@@ -38,13 +91,13 @@ export default function ComingSoon() {
                 <h3 className="font-semibold text-foreground mb-2">Groupes de Discussion</h3>
                 <p className="text-sm text-muted-foreground">Rejoignez des groupes thématiques et échangez avec la communauté</p>
               </div>
-              
+
               <div className="p-6 bg-background/30 backdrop-blur-sm border border-border/30 rounded-2xl">
                 <Bell className="w-8 h-8 text-primary mx-auto mb-4" />
                 <h3 className="font-semibold text-foreground mb-2">Événements</h3>
                 <p className="text-sm text-muted-foreground">Participez à des événements d'écriture et des ateliers</p>
               </div>
-              
+
               <div className="p-6 bg-background/30 backdrop-blur-sm border border-border/30 rounded-2xl">
                 <Clock className="w-8 h-8 text-primary mx-auto mb-4" />
                 <h3 className="font-semibold text-foreground mb-2">Défis d'Écriture</h3>
@@ -53,18 +106,57 @@ export default function ComingSoon() {
             </div>
 
             {/* CTA */}
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link to="/">
-                <Button size="lg" variant="outline" className="border-border text-foreground hover:bg-muted">
-                  <ArrowLeft className="w-4 h-4 mr-2" />
-                  Retour à l'accueil
+            {showForm ? (
+              <form
+                onSubmit={handleSubmit}
+                className="flex flex-col sm:flex-row gap-3 justify-center max-w-md mx-auto"
+              >
+                <Input
+                  type="email"
+                  inputMode="email"
+                  autoFocus
+                  required
+                  placeholder="votre@email.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={isSubmitting}
+                  className="h-11"
+                  aria-label="Adresse email"
+                />
+                <Button
+                  type="submit"
+                  size="lg"
+                  disabled={isSubmitting}
+                  className="bg-primary text-primary-foreground hover:bg-primary/90 shrink-0"
+                >
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Inscription…
+                    </>
+                  ) : (
+                    "M'inscrire"
+                  )}
                 </Button>
-              </Link>
-              <Button size="lg" className="bg-primary text-primary-foreground hover:bg-primary/90">
-                <Bell className="w-4 h-4 mr-2" />
-                Me notifier
-              </Button>
-            </div>
+              </form>
+            ) : (
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <Link to="/">
+                  <Button size="lg" variant="outline" className="border-border text-foreground hover:bg-muted">
+                    <ArrowLeft className="w-4 h-4 mr-2" />
+                    Retour à l'accueil
+                  </Button>
+                </Link>
+                <Button
+                  size="lg"
+                  onClick={() => setShowForm(true)}
+                  className="bg-primary text-primary-foreground hover:bg-primary/90"
+                >
+                  <Bell className="w-4 h-4 mr-2" />
+                  Me notifier
+                </Button>
+              </div>
+            )}
           </div>
         </AnimateOnView>
       </Container>


### PR DESCRIPTION
Le bouton « Me notifier » de la page Bientôt Disponible n'avait aucun gestionnaire. Il ouvre désormais un champ email et inscrit réellement l'utilisateur à une liste d'attente.

Backend
- Modèle WaitlistEntry (email unique + validé, source, timestamps)
- Service idempotent : une email déjà inscrite ne lève pas d'erreur
- Route publique POST /api/waitlist avec validation de schéma et rate limiting anti-spam (5/min/IP)

Frontend
- ComingSoon : le CTA révèle un formulaire email, soumet à l'API et affiche un toast de confirmation/erreur
- Nouvel endpoint waitlist dans api.config


Claude-Session: https://claude.ai/code/session_017iid7TLyp32F9GZAFRETWL